### PR TITLE
Updated models/flexible_storage_uploaded_files

### DIFF
--- a/models/flexible_storage_uploaded_files.rst
+++ b/models/flexible_storage_uploaded_files.rst
@@ -17,11 +17,11 @@ Flexible storage of uploaded files
 
 ::
 
-	from massmedia.settings import IMAGE_UPLOAD_TO, DEFAULT_STORAGE
+	from django.conf import settings
 
 	class Image(models.Model):
 	    file = models.FileField(
-	        upload_to = IMAGE_UPLOAD_TO,
+	        upload_to = settings.IMAGE_UPLOAD_TO,
 	        blank = True, 
 	        null = True,
-	        storage=DEFAULT_STORAGE())
+	        storage=settings.DEFAULT_STORAGE())


### PR DESCRIPTION
Per https://docs.djangoproject.com/en/1.3/topics/settings/#using-settings-in-python-code, don't import the local settings file, but import settings from django.conf instead.
